### PR TITLE
[MOB-11357] fix autoconfigurepush bug on android

### DIFF
--- a/plugin/src/withPushNotifications/index.ts
+++ b/plugin/src/withPushNotifications/index.ts
@@ -7,6 +7,14 @@ import { withIosPushNotifications } from './withIosPushNotifications';
 export const withPushNotifications: ConfigPlugin<
   ConfigPluginPropsWithDefaults
 > = (config, props) => {
+  /**
+   * No need to do anything if `props.autoConfigurePushNotifications` is
+   * explicitly set to `false`.
+   */
+  if (props.autoConfigurePushNotifications === false) {
+    return config;
+  }
+
   return withPlugins(config, [
     [withIosPushNotifications, props],
     [withAndroidPushNotifications, props],

--- a/plugin/src/withPushNotifications/withIosPushNotifications.ts
+++ b/plugin/src/withPushNotifications/withIosPushNotifications.ts
@@ -294,14 +294,6 @@ end`;
 export const withIosPushNotifications: ConfigPlugin<
   ConfigPluginPropsWithDefaults
 > = (config, props) => {
-  /**
-   * No need to do anything if `props.autoConfigurePushNotifications` is
-   * explicitly set to `false`.
-   */
-  if (props.autoConfigurePushNotifications === false) {
-    return config;
-  }
-
   return withPlugins(config, [
     [withCapabilities, props],
     [withBackgroundModes, props],


### PR DESCRIPTION
## 🎟️ JIRA ticket(s)

- [MOB-1234](https://iterable.atlassian.net/browse/MOB-1234)

## 🏕 Description

Fixed autoconfigurepush still building in android

## 📷 Screenshots

n/a

## 🧐 Testing

1. change `autoConfigurePushNotifications` to `false` in example app.json
2. in the example folder, run `npx expo prebuild --clean`
3. run `yarn android`
4. check that notifications are not coming through

## 📝 Documentation

n/a


[MOB-1234]: https://iterable.atlassian.net/browse/MOB-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ