### PR TITLE
[MOB-12257] update @iterable/react-native-sdk to version 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - 2025-11-19
+
+### Changed
+- Updated `@iterable/react-native-sdk` to `^2.1.0`
+
 ## [1.0.1] - 2025-07-16
 
 ### Changed

--- a/example/package.json
+++ b/example/package.json
@@ -11,7 +11,7 @@
     "open:android": "open -a \"Android Studio\" android"
   },
   "dependencies": {
-    "@iterable/react-native-sdk": "^2.0.2",
+    "@iterable/react-native-sdk": "^2.1.0",
     "@react-navigation/native": "^7.0.19",
     "@react-navigation/stack": "^7.2.3",
     "expo": "^53.0.19",

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -1481,20 +1481,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@iterable/react-native-sdk@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "@iterable/react-native-sdk@npm:2.0.2"
+"@iterable/react-native-sdk@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@iterable/react-native-sdk@npm:2.1.0"
   peerDependencies:
     "@react-navigation/native": "*"
     react: "*"
     react-native: "*"
     react-native-safe-area-context: "*"
-    react-native-vector-icons: "*"
     react-native-webview: "*"
   peerDependenciesMeta:
     expo:
       optional: true
-  checksum: 10c0/d1d6485dd3b982642df9569a4793aae0ff71191f8f6faffadbb580594db8e9cf2089f8a9b668d09c7b53e93ecbcd9d054833a8b82e0bb2a1d0d9a68a269d5967
+  checksum: 10c0/925492e228c786df0c2193a3bc0a9c8a590fe16a096bc76cc7e82f49c12c6eb62ec5a67a895e15a013f3473c839f04411a484975ffca218e60b92f71fed4cb06
   languageName: node
   linkType: hard
 
@@ -3309,7 +3308,7 @@ __metadata:
   resolution: "expo-plugin-example@workspace:."
   dependencies:
     "@babel/core": "npm:^7.25.2"
-    "@iterable/react-native-sdk": "npm:^2.0.2"
+    "@iterable/react-native-sdk": "npm:^2.1.0"
     "@react-navigation/native": "npm:^7.0.19"
     "@react-navigation/stack": "npm:^7.2.3"
     "@types/react": "npm:~19.0.10"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@commitlint/config-conventional": "^19.6.0",
     "@evilmartians/lefthook": "^1.5.0",
-    "@iterable/react-native-sdk": "^2.0.2",
+    "@iterable/react-native-sdk": "^2.1.0",
     "@react-native/eslint-config": "^0.79.5",
     "@release-it/conventional-changelog": "^9.0.2",
     "@types/jest": "^29.5.14",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iterable/expo-plugin",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Config plugin for @iterable/react-native-sdk",
   "main": "build/withIterable.js",
   "types": "build/withIterable.d.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2669,7 +2669,7 @@ __metadata:
   dependencies:
     "@commitlint/config-conventional": "npm:^19.6.0"
     "@evilmartians/lefthook": "npm:^1.5.0"
-    "@iterable/react-native-sdk": "npm:^2.0.2"
+    "@iterable/react-native-sdk": "npm:^2.1.0"
     "@react-native/eslint-config": "npm:^0.79.5"
     "@release-it/conventional-changelog": "npm:^9.0.2"
     "@types/jest": "npm:^29.5.14"
@@ -2702,20 +2702,19 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@iterable/react-native-sdk@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "@iterable/react-native-sdk@npm:2.0.2"
+"@iterable/react-native-sdk@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@iterable/react-native-sdk@npm:2.1.0"
   peerDependencies:
     "@react-navigation/native": "*"
     react: "*"
     react-native: "*"
     react-native-safe-area-context: "*"
-    react-native-vector-icons: "*"
     react-native-webview: "*"
   peerDependenciesMeta:
     expo:
       optional: true
-  checksum: 10c0/d1d6485dd3b982642df9569a4793aae0ff71191f8f6faffadbb580594db8e9cf2089f8a9b668d09c7b53e93ecbcd9d054833a8b82e0bb2a1d0d9a68a269d5967
+  checksum: 10c0/925492e228c786df0c2193a3bc0a9c8a590fe16a096bc76cc7e82f49c12c6eb62ec5a67a895e15a013f3473c839f04411a484975ffca218e60b92f71fed4cb06
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 🎟️ JIRA ticket(s)

- [MOB-12257](https://iterable.atlassian.net/browse/MOB-12257)

## 🏕 Description

Upgraded @iterable/react-native-sdk to latest

## 📷 Screenshots

n/a

## 🧐 Testing

n/a

## 📝 Documentation

n/a


[MOB-12257]: https://iterable.atlassian.net/browse/MOB-12257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ