### PR TITLE
fix: correct package entry paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "@iterable/expo-plugin",
   "version": "1.0.1",
   "description": "Config plugin for @iterable/react-native-sdk",
-  "main": "build/withIterable.js",
-  "types": "build/withIterable.d.ts",
+  "main": "plugin/build/withIterable.js",
+  "types": "plugin/build/withIterable.d.ts",
   "scripts": {
     "build": "expo-module build",
     "clean": "expo-module clean",


### PR DESCRIPTION
## Summary

- point the package `main` entry at `plugin/build/withIterable.js`
- point the package `types` entry at `plugin/build/withIterable.d.ts`

## Why

The published `@iterable/expo-plugin@1.0.2` package declares `main: "build/withIterable.js"` and `types: "build/withIterable.d.ts"`, but those files are not present in the npm tarball. The plugin build output is published under `plugin/build/`, which is also the path used by `app.plugin.js`.

## Validation

- checked the published npm tarball: `package/build/withIterable.js` and `.d.ts` are absent, while `package/plugin/build/withIterable.js` and `.d.ts` are present
- `corepack yarn install --immutable`
- `corepack yarn tsc -p plugin/tsconfig.json --pretty false`
- `npm pack --dry-run --ignore-scripts --json` confirms the updated `main` and `types` files are included
- `git diff --check`