### PR TITLE
docs: fix package name in README notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,10 +379,10 @@ If you encounter the error "Signing for 'IterableExpoRichPush' requires a develo
 - Your expo app needs to be run as a [development
   build](https://docs.expo.dev/develop/development-builds/introduction/) instead
   of through Expo Go. Both
-  `@iterable/iterable-expo-plugin` and `@iterable/react-native-sdk` will **NOT** work in Expo Go
+  `@iterable/expo-plugin` and `@iterable/react-native-sdk` will **NOT** work in Expo Go
   as they are reliant on native code, which Expo Go [does not
   support](https://expo.dev/blog/expo-go-vs-development-builds#expo-go-limitations).
-- `@iterable/iterable-expo-plugin` is intended for managed workflows, and will
+- `@iterable/expo-plugin` is intended for managed workflows, and will
   overwrite the files in your `ios` and `android` directories. Any manual
   changes to those directories will be overwritten on the next build.
 - This plugin has been tested on Expo SDK 55. While it may work on previous


### PR DESCRIPTION
## Summary
- Two notes in the README referenced `@iterable/iterable-expo-plugin`, which is not the published package name.
- Corrected both to `@iterable/expo-plugin`, matching `package.json` (`"name": "@iterable/expo-plugin"`), the install/config instructions elsewhere in the README, and the npm registry (`@iterable/iterable-expo-plugin` is not published).

## Context
Surfaced while validating iterable-docs PR [#1556](https://github.com/Iterable/iterable-docs/pull/1556), which normalizes docs to `@iterable/expo-plugin`. These two README lines were the last stragglers using the wrong name.

## Test plan
- [x] Docs-only change, no code affected
- [x] Verified no other `@iterable/iterable-expo-plugin` package references remain (repo slug/URLs intentionally unchanged)